### PR TITLE
Moved Foundation.js call to fix loading sequence. This fixes an issue wh...

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -23,13 +23,6 @@
 		<!-- all js scripts are loaded in library/joints.php -->
 		<?php wp_footer(); ?>
 
-<script>
-	(function(jQuery) {
-		jQuery(document).foundation();
-	})(jQuery);
-</script>
-
-
 	</body>
 
 </html> <!-- end page -->

--- a/library/js/scripts.js
+++ b/library/js/scripts.js
@@ -105,3 +105,10 @@ jQuery(document).ready(function($) {
 	w.addEventListener( "orientationchange", restoreZoom, false );
 	w.addEventListener( "devicemotion", checkTilt, false );
 })( this );
+
+/*
+ * Load up Foundation
+ */
+(function(jQuery) {
+  jQuery(document).foundation();
+})(jQuery);


### PR DESCRIPTION
...ere Foundation wasn't loading properly when using NextGen Gallery plugin, and likely others. The issue was the page script was being run before all the enqueued scripts were loaded. This caused foundation() to be called before the foundation.js was loaded in some cases.
