### PR TITLE
Make JointsWP child theme friendly

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -23,14 +23,14 @@ library/joints.php
 	- custom google+ integration
 	- adding custom fields to user profiles
 */
-require_once('library/joints.php'); // if you remove this, Joints will break
+require_once(get_template_directory().'/library/joints.php'); // if you remove this, Joints will break
 /*
 library/custom-post-type.php
 	- an example custom post type
 	- example custom taxonomy (like categories)
 	- example custom taxonomy (like tags)
 */
-require_once('library/custom-post-type.php'); // you can disable this if you like
+require_once(get_template_directory().'/library/custom-post-type.php'); // you can disable this if you like
 /*
 library/admin.php
 	- removing some default WordPress dashboard widgets
@@ -38,12 +38,12 @@ library/admin.php
 	- adding custom login css
 	- changing text in footer of admin
 */
-// require_once('library/admin.php'); // this comes turned off by default
+// require_once(get_template_directory().'/library/admin.php'); // this comes turned off by default
 /*
 library/translation/translation.php
 	- adding support for other languages
 */
-// require_once('library/translation/translation.php'); // this comes turned off by default
+// require_once(get_template_directory().'/library/translation/translation.php'); // this comes turned off by default
 
 /*********************
 THUMNAIL SIZE OPTIONS

--- a/library/joints.php
+++ b/library/joints.php
@@ -122,16 +122,16 @@ function joints_scripts_and_styles() {
   if (!is_admin()) {
 
     // modernizr (without media query polyfill)
-    wp_register_script( 'joints-modernizr', get_stylesheet_directory_uri() . '/library/js/vendor/custom.modernizr.js', array(), '2.5.3', false );
+    wp_register_script( 'joints-modernizr', get_template_directory_uri() . '/library/js/vendor/custom.modernizr.js', array(), '2.5.3', false );
     
     // adding Foundation scripts file in the footer
     wp_register_script( 'foundation-js', get_template_directory_uri() . '/library/js/foundation.min.js', array( 'jquery' ), '', true );
    
     // register main stylesheet
-    wp_register_style( 'joints-stylesheet', get_stylesheet_directory_uri() . '/library/css/style.css', array(), '', 'all' );
+    wp_register_style( 'joints-stylesheet', get_template_directory_uri() . '/library/css/style.css', array(), '', 'all' );
     
     // register foundation icons
-    wp_register_style( 'foundation-icons', get_stylesheet_directory_uri() . '/library/css/icons/foundation-icons.css', array(), '', 'all' );
+    wp_register_style( 'foundation-icons', get_template_directory_uri() . '/library/css/icons/foundation-icons.css', array(), '', 'all' );
 
     // comment reply script for threaded comments
     if ( is_singular() AND comments_open() AND (get_option('thread_comments') == 1)) {
@@ -139,7 +139,7 @@ function joints_scripts_and_styles() {
     }
 
     //adding scripts file in the footer
-    wp_register_script( 'joints-js', get_stylesheet_directory_uri() . '/library/js/scripts.js', array( 'jquery' ), '', true );
+    wp_register_script( 'joints-js', get_template_directory_uri() . '/library/js/scripts.js', array( 'jquery' ), '', true );
 
     // enqueue styles and scripts
     wp_enqueue_script( 'joints-modernizr' );


### PR DESCRIPTION
Right now JointsWP does not work with child themes because it makes some assumptions about where certain files are located. By changing a few things where files are added to the theme, I was able to make this friendly with child themes.
