### PR TITLE
Disable custom post types by default

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -30,8 +30,11 @@ library/custom-post-type.php
 	- example custom taxonomy (like categories)
 	- example custom taxonomy (like tags)
 */
-require_once(get_template_directory().'/library/custom-post-type-accordion.php'); // you can disable this if you like
-require_once(get_template_directory().'/library/custom-post-type.php'); // you can disable this if you like
+/*
+Uncomment the following files to utilize the example post types.
+*/
+//require_once(get_template_directory().'/library/custom-post-type-accordion.php'); // you can enable this if you like
+//require_once(get_template_directory().'/library/custom-post-type.php'); // you can enable this if you like
 /*
 library/admin.php
 	- removing some default WordPress dashboard widgets


### PR DESCRIPTION
I consider it better to leave out this functionality by default by commenting out the requires and allowing developers to utilize them if they need to. Otherwise I/others have to go in and do this every time we start a new project and don't want these post types.