### PR TITLE
adjust loop-page template part

### DIFF
--- a/partials/loop-page.php
+++ b/partials/loop-page.php
@@ -1,4 +1,4 @@
-<article id="post-<?php the_ID(); ?>" <?php post_class('clearfix'); ?> role="article" itemscope itemtype="http://schema.org/BlogPosting">
+<article id="post-<?php the_ID(); ?>" <?php post_class('clearfix'); ?> role="article" itemscope itemtype="http://schema.org/WebPage">
 						
 	<header class="article-header">
 		<h1 class="page-title"><?php the_title(); ?></h1>


### PR DESCRIPTION
The reason for this pull request is that I think tags belong to Posts, not to Pages and personally I hardly ever use comments on Pages. By commenting out the call for the comments_template, users that want comments can just uncomment it.
I also adjusted the itemtype as I think WebPage suits better to a WordPress Page than BlogPosting.
