### PR TITLE
add_theme_support('html5', …)

### DIFF
--- a/library/joints.php
+++ b/library/joints.php
@@ -195,6 +195,16 @@ function joints_theme_support() {
 
 	// wp menus
 	add_theme_support( 'menus' );
+	
+	//html5 support (http://themeshaper.com/2013/08/01/html5-support-in-wordpress-core/)
+	add_theme_support( 'html5', 
+	         array( 
+	         	'comment-list', 
+	         	'comment-form', 
+	         	'search-form', 
+	         ) 
+	);
+	
 
 } /* end joints theme support */
 


### PR DESCRIPTION
Add theme support for HTML5 as described in http://themeshaper.com/2013/08/01/html5-support-in-wordpress-core/. WordPress 3.9 will also add theme support for 'gallery'.
