### PR TITLE
Minor changes in Translation

### DIFF
--- a/library/translation/de_DE.po
+++ b/library/translation/de_DE.po
@@ -12,7 +12,9 @@ msgstr ""
 "X-Poedit-SourceCharset: utf-8\n"
 "X-Poedit-KeywordsList: __;_e;_n\n"
 "X-Poedit-Basepath: /home/fulgor/GIT/bones\n"
-"Last-Translator: \n"
+"Last-Translator: Pixolin <pixolin@gmx.com>\n"
+"Language: de_DE\n"
+"X-Generator: Poedit 1.6.4\n"
 "X-Poedit-SearchPath-0: .\n"
 
 #: comments.php:12
@@ -165,13 +167,13 @@ msgstr "durchsuchen ..."
 
 #: 404.php:11
 msgid "Epic 404 - Article Not Found"
-msgstr "404 - Artikel wurde nicht gefunden"
+msgstr "404 - Beitrag wurde nicht gefunden"
 
 #: 404.php:17
 msgid ""
 "The article you were looking for was not found, but maybe try looking again!"
 msgstr ""
-"Der gesuchte Artikel wurde nicht gefunden. Versuchen Sie es mit einem "
+"Der gesuchte Beitrag wurde nicht gefunden. Versuchen Sie es mit einem "
 "ähnlichen Suchbegriff."
 
 #: search.php:7
@@ -245,7 +247,7 @@ msgstr "Die angefragte Quelle konnte nicht gefunden werden."
 
 #: sidebar.php:15
 msgid "Please activate some Widgets."
-msgstr "Bitte nutzen Sie doch ein paar Widgets."
+msgstr "Bitte aktivieren Sie ein paar Widgets."
 
 #: library/bones.php:52
 msgid "Read more &raquo;"
@@ -273,19 +275,19 @@ msgstr "Bearbeiten"
 
 #: library/custom-post-type.php:29
 msgid "Edit Post Types"
-msgstr "Eintrags-Arten bearbeiten"
+msgstr "Beitrags-Arten bearbeiten"
 
 #: library/custom-post-type.php:30
 msgid "New Post Type"
-msgstr "Neue Eintrags-Art"
+msgstr "Neue Beitrags-Art"
 
 #: library/custom-post-type.php:31
 msgid "View Post Type"
-msgstr "Zeige Eintrags-Art"
+msgstr "Zeige Beitrags-Art"
 
 #: library/custom-post-type.php:32
 msgid "Search Post Type"
-msgstr "Suche Eintrags-Art"
+msgstr "Suche Beitrags-Art"
 
 #: library/custom-post-type.php:33
 msgid "Nothing found in the Database."
@@ -297,7 +299,7 @@ msgstr "Im Papierkorb wurde nichts gefunden"
 
 #: library/custom-post-type.php:37
 msgid "This is the example custom post type"
-msgstr "Beispel für eine eigene Eintrags-Art"
+msgstr "Beispiel für eine eigene Beitrags-Art"
 
 #: library/custom-post-type.php:73
 msgid "Custom Categories"


### PR DESCRIPTION
German Translation of WordPress 3.8.1 uses "Beitrag" as translation for "Post". Hence the german translation for JointsWP should use terms such as "Beitragsart" (post type) instead of the "Eintragsart" (entry type), which certainly isn't wrong but not using the "official terms".

I also changed the translation for "please activate some widgets" which was translated as "Bitte nutzen Sie doch ein paar Widgets." ("After all, use some widgets, please.") into "Bitte aktivieren Sie ein paar Widgets." which is more literal.

As the references mentions, this are all very minor changes. Generally the translation is of good quality. Danke sehr.
