### PR TITLE
link .left-off-canvas-toggle needs href="#off-canvas-navigation" to work...

### DIFF
--- a/partials/nav-offcanvas.php
+++ b/partials/nav-offcanvas.php
@@ -28,7 +28,7 @@
 				<h1 class="title"><?php bloginfo('name'); ?></h1>
 			</section>
 			<section class="left-small">
-				<a class="left-off-canvas-toggle menu-icon" ><span></span></a>
+				<a class="left-off-canvas-toggle menu-icon" href="#off-canvas-navigation"><span></span></a>
 			</section>
 		</nav>
 	</div>


### PR DESCRIPTION
... on iPhone

Added href="#off-canvas-navigation" to make the link work on iPhone.
source: http://foundation.zurb.com/forum/posts/1651-cant-get-off-canvas-to-toggle-on-mobile