### PR TITLE
enable language files by default (remove comment)

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -44,7 +44,7 @@ library/admin.php
 library/translation/translation.php
 	- adding support for other languages
 */
-// require_once(get_template_directory().'/library/translation/translation.php'); // this comes turned off by default
+require_once(get_template_directory().'/library/translation/translation.php');
 
 /*********************
 THUMNAIL SIZE OPTIONS


### PR DESCRIPTION
WordPress foundation encourages internationalization of themes and plugins. As JointsWP does provide language files, I see no reason, not to use them by default (as e.g. all WordPress Twenty* themes do). Even more, having it disabled by default gives a first impression of the theme not being translated (e.g. in Live Preview Mode).