### PR TITLE
Changed Foundation Version Number

### DIFF
--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ Author URI: http://www.yoururlhere.com
 Version: 1.5 (Sass)
 Tags: 
 
-Foundation Version: 5.1.1
+Foundation Version: 5.2
 
 ------------------------------------------------------------------
 


### PR DESCRIPTION
After switching to Foundation 5.2 the version number should be reflected here
