### PR TITLE
Move modernizr and jquery back to parent theme

### DIFF
--- a/library/joints.php
+++ b/library/joints.php
@@ -124,10 +124,10 @@ function joints_scripts_and_styles() {
 	wp_deregister_script('jquery');
 	
 // modernizr (without media query polyfill)
-    wp_enqueue_script( 'jquery', get_stylesheet_directory_uri() . '/bower_components/foundation/js/vendor/jquery.js', array(), '2.1.0', false );
+    wp_enqueue_script( 'jquery', get_template_directory_uri() . '/bower_components/foundation/js/vendor/jquery.js', array(), '2.1.0', false );
     
     // modernizr (without media query polyfill)
-    wp_enqueue_script( 'modernizr', get_stylesheet_directory_uri() . '/bower_components/foundation/js/vendor/modernizr.js', array(), '2.5.3', false );
+    wp_enqueue_script( 'modernizr', get_template_directory_uri() . '/bower_components/foundation/js/vendor/modernizr.js', array(), '2.5.3', false );
     
     // adding Foundation scripts file in the footer
     wp_enqueue_script( 'foundation-js', get_template_directory_uri() . '/bower_components/foundation/js/foundation.min.js', array( 'jquery' ), '', true );


### PR DESCRIPTION
I don't think that child themes should be responsible for including jquery and modernizr. They already exist in the theme as a parent, they should be loaded from the parent.
Keeping this as-is causes child themes to break as soon as they are created because the child theme will not include these files. Considering they will not be altered if copied to the child theme, I think they should stay with the parent.
