### PR TITLE
Added function for more elaborated copyright

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -5,14 +5,14 @@
 		    						<?php joints_footer_links(); ?>
 		    					</nav>
 		    				</div>
-			                <div class="large-12 medium-12 columns">		
-								<p class="source-org copyright">&copy; <?php echo date('Y'); ?> <?php bloginfo('name'); ?>.</p>
-							</div>		
-						</div> <!-- end #inner-footer -->			
+			                <div class="large-12 medium-12 columns">
+								<p class="source-org copyright"><?php echo joints_copyright(); ?> <?php bloginfo('name'); ?>.</p>
+							</div>
+						</div> <!-- end #inner-footer -->
 					</footer> <!-- end .footer -->
 				</div> <!-- end #container -->
 			</div> <!-- end .inner-wrap -->
-		</div> <!-- end .off-canvas-wrap -->		
+		</div> <!-- end .off-canvas-wrap -->
 		<!-- all js scripts are loaded in library/joints.php -->
 		<?php wp_footer(); ?>
 	</body>

--- a/functions.php
+++ b/functions.php
@@ -218,4 +218,32 @@ function joints_comments($comment, $args, $depth) {
 <?php
 } // don't remove this bracket!
 
+
+/*
+* Code provided by Philip M. Hofer adds Year of Copyright for first and last post (e.g. 2012–2014)
+* http://premium.wpmudev.org/blog/daily-tip-how-to-add-a-dynamic-copyright-date-in-the-footer/#comment-13309
+*/
+if (!function_exists('joints_copyright')) {
+    function joints_copyright() {
+        global $wpdb;
+        $copyright_dates = $wpdb->get_results("
+                    SELECT
+                    YEAR(min(post_date_gmt)) AS firstdate,
+                    YEAR(max(post_date_gmt)) AS lastdate
+                    FROM
+                    $wpdb->posts
+                    WHERE
+                    post_status = 'publish'
+                    ");
+        $output = '';
+        if($copyright_dates) {
+            $copyright = "© " . $copyright_dates[0]->firstdate;
+            if($copyright_dates[0]->firstdate != $copyright_dates[0]->lastdate) {
+                $copyright .= '-' . $copyright_dates[0]->lastdate;
+            }
+            $output =  $copyright;
+        }
+        return $output;
+    }
+}
 ?>


### PR DESCRIPTION
Currently the template for the footer (footer.php) retrieves the year of the latest post to show a copyright notice in the footer of the website. Although widely used, to my knowledge this is not entirely correct: 

> The copyright notice on a work establishes a claim to copyright. The date on the notice establishes how far back the claim is made. This means if you update the date, you are no longer claiming the copyright for the original date and that means if somebody has copied the work in the meantime and they claim its theirs on the ground that their publishing the copy was before your claim, then it will be difficult to establish who is the originator of the work.
> (quote: user "[Dirty Henry](http://stackoverflow.com/users/455016/dirty-henry)" on [Stack Overflow](http://stackoverflow.com/a/2391555).)

To have a more elaborated copyright notice, [Philip M. Hofer](http://frumph.net/) suggested to use following code snippet (his comment can be found on [wpmudev-Blog](http://http://premium.wpmudev.org/blog/daily-tip-how-to-add-a-dynamic-copyright-date-in-the-footer/#comment-13309)). His snippets retrieves the Year of the first and last blog post and provides that as a copyright notice.

In this pull request, I have added the snippet to functions.php and used the function in footer.php.
