### PR TITLE
header.php apple touch icon filename does not match that of the file in library/images

### DIFF
--- a/header.php
+++ b/header.php
@@ -15,7 +15,7 @@
 
 		<!-- Icons & Favicons -->
 		<link rel="icon" href="<?php echo get_template_directory_uri(); ?>/favicon.png">
-		<link href="<?php echo get_template_directory_uri(); ?>/library/images/apple-touch-icon.png" rel="apple-touch-icon" />
+		<link href="<?php echo get_template_directory_uri(); ?>/library/images/apple-icon-touch.png" rel="apple-touch-icon" />
 		<!--[if IE]>
 			<link rel="shortcut icon" href="<?php echo get_template_directory_uri(); ?>/favicon.ico">
 		<![endif]-->


### PR DESCRIPTION
small fix to avoid a 404 on the "missing" asset.