### PR TITLE
Stop "gulp watch" from crashing on an undefined variable

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,10 @@ var gulp  = require('gulp'),
 // Compile Sass, Autoprefix and minify
 gulp.task('styles', function() {
   return gulp.src('./assets/scss/**/*.scss')
-    .pipe(plumber())
+    .pipe(plumber(function(error) {
+            gutil.log(gutil.colors.red(error.message));
+            this.emit('end');
+    }))
     .pipe(sass())
     .pipe(autoprefixer({
             browsers: ['last 2 versions'],


### PR DESCRIPTION
If you're using "gulp watch", and happen to type a variable that's undefined, it will stop with an error about an unhandled error. The fix is to  pass gulp-plumber an error callback (Solution found here: https://github.com/yeoman/generator-gulp-webapp/issues/154#issuecomment-45990783).

Now instead of stopping, it will provide the error text in red, in the commandline.