### PR TITLE
WP 4.3 Backward-compatible favicons/icons

### DIFF
--- a/header.php
+++ b/header.php
@@ -10,16 +10,18 @@
 
 		<!-- Mobile Meta -->
 		<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-
-		<!-- Icons & Favicons -->
-		<link rel="icon" href="<?php echo get_template_directory_uri(); ?>/favicon.png">
-		<link href="<?php echo get_template_directory_uri(); ?>/assets/images/apple-icon-touch.png" rel="apple-touch-icon" />
-		<!--[if IE]>
-			<link rel="shortcut icon" href="<?php echo get_template_directory_uri(); ?>/favicon.ico">
-		<![endif]-->
-		<meta name="msapplication-TileColor" content="#f01d4f">
-		<meta name="msapplication-TileImage" content="<?php echo get_template_directory_uri(); ?>/assets/images/win8-tile-icon.png">
-	    <meta name="theme-color" content="#121212">
+		
+		<?php if ( ! function_exists( 'has_site_icon' ) || ! has_site_icon() ) { ?>
+			<!-- Icons & Favicons -->
+			<link rel="icon" href="<?php echo get_template_directory_uri(); ?>/favicon.png">
+			<link href="<?php echo get_template_directory_uri(); ?>/assets/images/apple-icon-touch.png" rel="apple-touch-icon" />
+			<!--[if IE]>
+				<link rel="shortcut icon" href="<?php echo get_template_directory_uri(); ?>/favicon.ico">
+			<![endif]-->
+			<meta name="msapplication-TileColor" content="#f01d4f">
+			<meta name="msapplication-TileImage" content="<?php echo get_template_directory_uri(); ?>/assets/images/win8-tile-icon.png">
+	    		<meta name="theme-color" content="#121212">
+	    	<?php } ?>
 
 		<link rel="pingback" href="<?php bloginfo('pingback_url'); ?>">
 


### PR DESCRIPTION
Since WordPress 4.3 supports "native favicons" (https://core.trac.wordpress.org/ticket/16434) we should update the output of theme favicon, Source: https://make.wordpress.org/themes/2015/08/28/backward-compatible-faviconsicons/