### PR TITLE
Link tab-bar title back to home page

### DIFF
--- a/parts/nav-top-offcanvas.php
+++ b/parts/nav-top-offcanvas.php
@@ -15,7 +15,9 @@
 <div class="show-for-small-only">
 	<nav class="tab-bar">
 		<section class="middle tab-bar-section">
-			<h1 class="title"><?php bloginfo('name'); ?></h1>
+			<a href="<?php get_site_url(); ?>" title="<?php bloginfo('name'); ?>">
+				<h1 class="title"><?php bloginfo('name'); ?></h1>
+			</a>
 		</section>
 		<section class="left-small">
 			<a href="#" class="left-off-canvas-toggle menu-icon" ><span></span></a>


### PR DESCRIPTION
Wrap the tab-bar title with a link to the homepage to provide a default way back to the home page from mobile navigation.