### PR TITLE
Allows use of custom query by passing it as third argument

### DIFF
--- a/assets/functions/page-navi.php
+++ b/assets/functions/page-navi.php
@@ -12,7 +12,7 @@ function joints_page_navi($before = '', $after = '', $query = '', $paged = '' ) 
 	}
 	
 	$request 		= $query->request;
-	$posts_per_page	= $query->query['posts_per_page'];
+	$posts_per_page	= $query->query_vars['posts_per_page'];
 	$numposts 		= $query->found_posts;
 	$max_page 		= $query->max_num_pages;
 

--- a/assets/functions/page-navi.php
+++ b/assets/functions/page-navi.php
@@ -1,13 +1,22 @@
 <?php
 // Numeric Page Navi (built into the theme by default)
-function joints_page_navi($before = '', $after = '') {
-	global $wpdb, $wp_query;
-	$request = $wp_query->request;
-	$posts_per_page = intval(get_query_var('posts_per_page'));
-	$paged = intval(get_query_var('paged'));
-	$numposts = $wp_query->found_posts;
-	$max_page = $wp_query->max_num_pages;
-	if ( $numposts <= $posts_per_page ) { return; }
+function joints_page_navi($before = '', $after = '', $query = '', $paged = '' ) {
+	
+	if( empty($query) ) {
+		global $wpdb, $wp_query;
+		$query = $wp_query;
+	}
+
+	if( empty($paged) ) {
+		$paged = intval(get_query_var('paged'));
+	}
+	
+	$request 		= $query->request;
+	$posts_per_page	= $query->query['posts_per_page'];
+	$numposts 		= $query->found_posts;
+	$max_page 		= $query->max_num_pages;
+
+	if ( $numposts <= $posts_per_page ) { return; } 
 	if(empty($paged) || $paged == 0) {
 		$paged = 1;
 	}


### PR DESCRIPTION
Allows use of custom query by passing it as third argument, along with the $paged value to give the current page number.

This fixes the problem where the pagination doesn't show up for custom post types so you can use a different variable to store the query.

`joints_page_navi('', '', $custom_query, $paged );`

Hope this is useful. Any questions just shout, or if it's wrong please tell me!


