### PR TITLE
add class of end to archive grid

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -6,5 +6,14 @@ and Foundation play nice together.
 
 // Remove empty P tags created by WP inside of Accordion and Orbit
 jQuery(document).ready(function() {
+
     jQuery('.accordion p:empty, .orbit p:empty').remove();
+
+	/**
+	 * For parts/loop-archive-grid.php
+	 * When the total number of posts is not dividable by 3, the last post float to the right.
+	 * This can be fixed by adding the end class to the last item, which then floats the last item to the left instead.
+	 */
+	jQuery( '.category-grid .columns.panel' ).last().addClass( 'end' );
+
 });


### PR DESCRIPTION
Hi again Jeremy,
And here separately the PR that adds the `end` class to the last grid item to prevent it from floating right when the total number of grid items is not dividable by 3.
Cheers,
Piet