### PR TITLE
Included foundation-flex-classes component as required by the default xy grid

### DIFF
--- a/assets/styles/scss/style.scss
+++ b/assets/styles/scss/style.scss
@@ -26,10 +26,10 @@ CSS file.
 // @include foundation-grid;
 
 // @include foundation-flex-grid;
-// @include foundation-flex-classes;
 
 @include foundation-xy-grid-classes;
 
+@include foundation-flex-classes;
 @include foundation-typography;
 @include foundation-forms;
 @include foundation-button;


### PR DESCRIPTION
JointsWP has the `foundation-xy-grid` enabled as the default grid, which is great! However, it's missing some flexbox classes out of the box, which prevents features like [alignment ](https://foundation.zurb.com/sites/docs/flexbox-utilities.html#horizontal-alignment) from working with the xy grid.

This pull request includes the `foundation-flex-classes` component by default. The precedence for this change can be found in the Foundation [Sass documentation page](https://foundation.zurb.com/sites/docs/sass.html#adjusting-css-output). In the below screenshot, note that `foundation-flex-classes` is included even when only `foundation-xy-grid-classes` is used as the default grid:

![image](https://user-images.githubusercontent.com/2219531/31997988-a8c7042c-b953-11e7-8e6e-cf696bf32a0b.png)

Another instance that justifies this change is found in the Foundation 6.4 package commit, file [foundation.scss](https://github.com/zurb/foundation-sites/blob/4e21634356da296edd2f1c3e65d91140f991008b/scss/foundation.scss#L127). Here, `foundation-flex-classes` is included when `$flex` is set to `true`, which is the case for both the `foundation-xy-grid-classes` and `foundation-flex-grid`.

Thanks for the consideration, and let me know if you have any questions!