### PR TITLE
Uncomment foundation-flex-classes for xy-grid

### DIFF
--- a/assets/styles/scss/style.scss
+++ b/assets/styles/scss/style.scss
@@ -22,12 +22,11 @@ CSS file.
 // Select the components you want to use
 @include foundation-global-styles;
 
-//Select the grid you would like to use
+// Select the grid you would like to use defaults to xy-grid
 // @include foundation-grid;
-
 // @include foundation-flex-grid;
-// @include foundation-flex-classes;
 
+@include foundation-flex-classes; // Note: Provides flex classes to both flex-grid and xy-grid. #Reference - https://github.com/JeremyEnglert/JointsWP/issues/294
 @include foundation-xy-grid-classes;
 
 @include foundation-typography;


### PR DESCRIPTION
Certain flex classes aren't duplicated into xy-grid classes and zurb expects you to use them both when using xy-grid.
See their current scss file - https://github.com/zurb/foundation-sites/blob/develop/scss/foundation.scss
The conditionals show when $flex and is xy-grid it will include both flex-classes and xy-grid-classes
To address issue #294