### PR TITLE
Cleaned up files array to avoid duplicate watching

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -151,9 +151,6 @@ gulp.task('browsersync', function() {
     
     // Watch these files
     var files = [
-    	SOURCE.styles, 
-    	SOURCE.scripts,
-    	SOURCE.images,
     	SOURCE.php,
     ];
 


### PR DESCRIPTION
To resolve the browsersync issues outlined in #282 I've removed the styles, scripts and images from the files array as they're being watched separately and the double-watching causes users reloading issues.