### PR TITLE
Drop .min reference to fix #325

### DIFF
--- a/functions/editor-styles.php
+++ b/functions/editor-styles.php
@@ -2,5 +2,5 @@
 // Adds your styles to the WordPress editor
 add_action( 'init', 'add_editor_styles' );
 function add_editor_styles() {
-    add_editor_style( get_template_directory_uri() . '/assets/styles/style.min.css' );
+    add_editor_style( get_template_directory_uri() . '/assets/styles/style.css' );
 }


### PR DESCRIPTION
Updating the reference as the theme no longer builds min files the minified file is the style.css itself.