### PR TITLE
Adds parameters to the cssnano() function call in the gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -122,7 +122,7 @@ gulp.task('styles', function() {
 		    ],
 		    cascade: false
 		}))
-		.pipe(plugin.cssnano())
+		.pipe(plugin.cssnano({safe: true, minifyFontValues: {removeQuotes: false}}))
 		.pipe(plugin.sourcemaps.write('.'))
 		.pipe(gulp.dest(ASSETS.styles))
 		.pipe(browserSync.reload({


### PR DESCRIPTION
I recently found this bug: https://discourse.roots.io/t/scss-compiler-is-removing-quotes-from-font-family-solved/7558/2

A font wasn't working on a site because the quotes around it were getting stripped by CSS Nano from font-family declarations.

I changed the original gulpfile by modifying the solution mentioned in the article.

Also, I added 

`safe: true `

to the function parameters to fix issues with z-index and background gradient values getting changed. Examples:

https://github.com/webpack-contrib/css-loader/issues/433
https://github.com/ben-eb/gulp-cssnano/issues/8