### PR TITLE
Add more constants to the JSHINT Config globals

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -73,7 +73,10 @@ const JSHINT_CONFIG = {
 	"node": true,
 	"globals": {
 		"document": true,
-		"jQuery": true
+		"window": true,
+		"jQuery": true,
+		"$": true,
+		"Foundation": true
 	}
 };
 

--- a/package.json
+++ b/package.json
@@ -41,10 +41,5 @@
     "watch": "gulp watch",
     "browsersync": "gulp browsersync",
     "update-foundation": "npm install foundation-sites"
-  },
-  "jshintConfig": {
-    "globals": {
-      "jQuery": true
-    }
   }
 }


### PR DESCRIPTION
Add Fix for #329 and other custom JS that uses Foundation, window or $ constants