### PR TITLE
Add touch command for mtime - Gulp4

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,6 +4,7 @@ var gulp  = require('gulp'),
     gutil = require('gulp-util'),
     browserSync = require('browser-sync').create(),
     filter = require('gulp-filter'),
+    touch = require('gulp-touch-cmd'),
     plugin = require('gulp-load-plugins')();
 
 
@@ -128,6 +129,7 @@ gulp.task('styles', function() {
 		.pipe(plugin.cssnano({safe: true, minifyFontValues: {removeQuotes: false}}))
 		.pipe(plugin.sourcemaps.write('.'))
 		.pipe(gulp.dest(ASSETS.styles))
+		.pipe(touch())
 		.pipe(browserSync.reload({
           stream: true
         }));

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.5",
     "gulp-wp-pot": "^2.0.4",
+    "gulp-touch-cmd": "^0.0.1",
     "jshint-stylish": "^2.0.0",
     "motion-ui": "^1.2.2"
   },


### PR DESCRIPTION
With gulp4 it seems mtime isn't updated on sass updates and now we have to touch it.
Fixes #383