### PR TITLE
Introduce .is-active to the active nav class as used from Foundation …

### DIFF
--- a/functions/menu.php
+++ b/functions/menu.php
@@ -85,6 +85,7 @@ function joints_footer_links_fallback() {
 function required_active_nav_class( $classes, $item ) {
 	if ( $item->current == 1 || $item->current_item_ancestor == true ) {
 		$classes[] = 'active';
+		$classes[] = 'is-active';
 	}
 	return $classes;
 }


### PR DESCRIPTION
…6.4.0 onwards

This addresses issues found in #397 where the $dropdown-menu-item-background-active didn't seem to apply. But the actual issue is Foundation now uses .is-active and not .active.

To preserve back-compat for other devs I've left .active present.