### PR TITLE
login_headertitle is deprecated

### DIFF
--- a/functions/login.php
+++ b/functions/login.php
@@ -13,4 +13,4 @@ function joints_login_title() { return get_option('blogname'); }
 // calling it only on the login page
 add_action( 'login_enqueue_scripts', 'joints_login_css', 10 );
 add_filter('login_headerurl', 'joints_login_url');
-add_filter('login_headertitle', 'joints_login_title');
+add_filter('login_headertext', 'joints_login_title');


### PR DESCRIPTION
Fixes error - 
Notice: login_headertitle is deprecated since version 5.2.0! Use login_headertext instead. Usage of the title attribute on the login logo is not recommended for accessibility reasons. on login screen when joints_login_title is actiive