### PR TITLE
Use gulp from npm repository to make it work without git dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "babel-preset-es2015": "^6.5.0",
     "browser-sync": "^2.11.0",
     "foundation-sites": "^6.5.3",
-    "gulp": "github:gulpjs/gulp#v4.0.0",
+    "gulp": "^4.0.2",
     "gulp-autoprefixer": "^2.3.1",
     "gulp-babel": "^6.1.2",
     "gulp-concat": "^2.5.2",


### PR DESCRIPTION
npm install didn't work out-of-the-box, notably on Windows machines with no git installed. Changing the gulp dependency from github in package.json to a regular one fixes the issue.

And while git should be present in every developer's toolbox, there isn't much of a reason to fetch gulp from github rather than the npm repository. Plus, setting up git on Windows is a bit more of a hassle on Windows machines. Hence, I'm making this PR. Hopefully this saves someone some time.